### PR TITLE
Enable py36 pipelines

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -47,7 +47,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -62,7 +62,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ software. I'd like to thank:
 - A huge thank to all the [hypothesis](https://github.com/HypothesisWorks/hypothesis)
   authors to their fantastic library, that helped me to find an miss-named
   variable bug that I worked very hard to add in a 6 lines of code wrapper! And
-  to this Data-driven testing with python article that had left me with the
-  desire to try the library.
+  to this [Data-driven testing with Python](https://www.develer.com/en/data-driven-testing-with-python/)
+  article that had left me with the desire to try the library.

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         # Source language
         "Programming Language :: Cython",
     ],

--- a/tests/test_tinyaes.py
+++ b/tests/test_tinyaes.py
@@ -6,27 +6,27 @@ from hypothesis.strategies import binary
 import tinyaes
 
 
-@fixture
+@fixture(scope='module')
 def aes_enc():
     return tinyaes.AES(b'0123456789ABCDEF',
                        b'1234567890ABCDEF')
 
 
-@fixture
+@fixture(scope='module')
 def aes_dec():
     # Need to have two same-keys instancies
     return tinyaes.AES(b'0123456789ABCDEF',
                        b'1234567890ABCDEF')
 
 
-@fixture
+@fixture(scope='module')
 def aes_dec2():
     # Different key for decoding test
     return tinyaes.AES(b'ABCDEF0123456789',
                        b'ABCDEF1234567890')
 
 
-@fixture
+@fixture(scope='module')
 def aes_dec3():
     # Different key for decoding test
     return tinyaes.AES(b'56789ABCDEF01234',


### PR DESCRIPTION
- enable Python 3.6 in test pipelines
- enable Python 3.6 deploy where missing (OSX and Windows)
- add explicit 3.6, 3.7 and 3.8 trove classifiers (closes #14)
- add missing link to [Data-driven testing with Python](https://www.develer.com/en/data-driven-testing-with-python/) in the README