### PR TITLE
Prepare 1.0.2rc1

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -47,7 +47,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -17,9 +17,9 @@ jobs:
       run: |
         git submodule update --init
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.2.1-manylinux1_x86_64
+      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux1_x86_64
       with:
-        python-versions: 'cp27-cp27m cp27-cp27mu cp36-cp36m cp37-cp37m cp38-cp38'
+        python-versions: 'cp27-cp27m cp27-cp27mu cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
         deploy-requirements: 'cython'
         system-packages: 'patchelf'
         package-path: ''
@@ -35,7 +35,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -62,7 +62,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Given the C API works modifying a buffer in-place, the wrapper offers:
 
 ## Release notes
 
+- 1.0.2rc1 (Apr 7, 2021):
+  - added release Python 3.9 on Windows, Linux (`manylinux1`) and OSX
+  - updated upstream [`tiny-AES-c`](https://github.com/kokke/tiny-AES-c) with
+    some cleanups and small optimizations
 - 1.0.1 (Jun 8, 2020):
   - release Python 3.6 OSX and Windows wheels
   - updated upstream [`tiny-AES-c`](https://github.com/kokke/tiny-AES-c) with

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     description="tiny-AES-c wrapper in Cython",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="1.0.1",
+    version="1.0.2rc1",
     author="Matteo Bertini",
     author_email="naufraghi@develer.com",
     url="https://github.com/naufraghi/tinyaes-py",

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         # Source language
         "Programming Language :: Cython",
     ],


### PR DESCRIPTION
 - 1.0.2rc1 (Apr 7, 2021):
  - added release Python 3.9 on Windows, Linux (`manylinux1`) and OSX
  - updated upstream [`tiny-AES-c`](https://github.com/kokke/tiny-AES-c) with some cleanups and small optimizations 