### PR TITLE
Bump version to 1.0.2 (with Python 3.9 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Given the C API works modifying a buffer in-place, the wrapper offers:
   the buffer in-place.
 
 ## Release notes
-
+- 1.0.2 (Nov 4, 2021): version bump from 1.0.2rc1
 - 1.0.2rc1 (Apr 7, 2021):
   - added release Python 3.9 on Windows, Linux (`manylinux1`) and OSX
   - updated upstream [`tiny-AES-c`](https://github.com/kokke/tiny-AES-c) with

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     description="tiny-AES-c wrapper in Cython",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="1.0.2rc1",
+    version="1.0.2",
     author="Matteo Bertini",
     author_email="naufraghi@develer.com",
     url="https://github.com/naufraghi/tinyaes-py",


### PR DESCRIPTION
Closes #20