### PR TITLE
bump cibuildwheel to correctly build py312

### DIFF
--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"


### PR DESCRIPTION
Hi @naufraghi,

Currently the py312 wheels are not present on pypi https://pypi.org/project/tinyaes/1.1.0/#files

Reviewing the changelog history for cibuildwheel: https://cibuildwheel.pypa.io/en/stable/changelog/
I believe the issue is because Python 3.12 was under the pre-release support at the current version used in the GitHub Action.

This change I believe should correctly pick up the new configuration to build the Python3.12 wheel as expected.

I believe the minimum version would be 2.15: https://cibuildwheel.pypa.io/en/stable/changelog/#v2150